### PR TITLE
:bug: On python version 3.10, graphics function require integers.

### DIFF
--- a/opencodeblocks/graphics/blocks/codeblock.py
+++ b/opencodeblocks/graphics/blocks/codeblock.py
@@ -17,9 +17,12 @@ class OCBCodeBlock(OCBBlock):
     def init_source_editor(self):
         source_editor_graphics = QGraphicsProxyWidget(self)
         source_editor = PythonEditor(self)
-        source_editor.setGeometry(self.edge_size, self.edge_size + self.title_height,
-                                  self.width - 2*self.edge_size,
-                                  self.height - self.title_height - 2*self.edge_size)
+        source_editor.setGeometry(
+            int(self.edge_size),
+            int(self.edge_size + self.title_height),
+            int(self.width - 2*self.edge_size),
+            int(self.height - self.title_height - 2*self.edge_size)
+        )
         source_editor_graphics.setWidget(source_editor)
         source_editor_graphics.setZValue(-1)
         return source_editor_graphics
@@ -27,9 +30,12 @@ class OCBCodeBlock(OCBBlock):
     def update_all(self):
         if hasattr(self, 'source_editor'):
             editor_widget = self.source_editor.widget()
-            editor_widget.setGeometry(self.edge_size,
-                self.edge_size + self.title_height, self._width - 2*self.edge_size,
-                self.height - self.title_height - 2*self.edge_size)
+            editor_widget.setGeometry(
+                int(self.edge_size),
+                int(self.edge_size + self.title_height),
+                int(self._width - 2*self.edge_size),
+                int(self.height - self.title_height - 2*self.edge_size)
+            )
         super().update_all()
 
     @property

--- a/opencodeblocks/graphics/socket.py
+++ b/opencodeblocks/graphics/socket.py
@@ -30,7 +30,7 @@ class OCBSocket(QGraphicsItem, Serializable):
 
         self.radius = radius
         self._pen = QPen(QColor(linecolor))
-        self._pen.setWidth(linewidth)
+        self._pen.setWidth(int(linewidth))
         self._brush = QBrush(QColor(color))
 
         self.metadata = {
@@ -58,7 +58,7 @@ class OCBSocket(QGraphicsItem, Serializable):
         painter.setBrush(self._brush)
         painter.setPen(self._pen)
         r = self.radius
-        painter.drawEllipse(-r, -r, 2*r, 2*r)
+        painter.drawEllipse(int(-r),int(-r),int(2*r),int(2*r))
 
     def boundingRect(self) -> QRectF:
         r = self.radius
@@ -81,5 +81,5 @@ class OCBSocket(QGraphicsItem, Serializable):
 
         self.metadata = dict(data['metadata'])
         self._pen.setColor(QColor(self.metadata['linecolor']))
-        self._pen.setWidth(self.metadata['linewidth'])
+        self._pen.setWidth(int(self.metadata['linewidth']))
         self._brush.setColor(QColor(self.metadata['color']))


### PR DESCRIPTION
On python version 3.10 some graphics function need int parameters instead of floats.

Did the proper type conversions to get the app running.