### PR TITLE
:tada: Add file_has_changed dialog

### DIFF
--- a/opencodeblocks/graphics/scene/clipboard.py
+++ b/opencodeblocks/graphics/scene/clipboard.py
@@ -14,6 +14,7 @@ from opencodeblocks.graphics.edge import OCBEdge
 
 if TYPE_CHECKING:
     from opencodeblocks.graphics.scene import OCBScene
+    from opencodeblocks.graphics.view import OCBView
 
 
 class SceneClipboard():
@@ -26,6 +27,18 @@ class SceneClipboard():
 
     def __init__(self, scene:'OCBScene'):
         self.scene = scene
+
+    def views(self) -> 'OCBView':
+        return super().views()
+
+    def cut(self):
+        self._store(self._serializeSelected(delete=True))
+
+    def copy(self):
+        self._store(self._serializeSelected(delete=False))
+
+    def paste(self):
+        self._deserializeData(self._gatherData())
 
     def _serializeSelected(self, delete=False) -> OrderedDict:
         selected_blocks, selected_edges = self.scene.sortedSelectedItems()
@@ -98,7 +111,7 @@ class SceneClipboard():
             self.scene.addItem(edge)
             hashmap.update({edge_data['id']: edge})
 
-        self.scene.history.checkpoint('Desiralized elements into scene')
+        self.scene.history.checkpoint('Desiralized elements into scene', set_modified=True)
 
     def _store(self, data:OrderedDict):
         str_data = json.dumps(data, indent=4)
@@ -111,12 +124,3 @@ class SceneClipboard():
         except ValueError as valueerror:
             warn(f"Clipboard text could not be loaded into json data: {valueerror}")
             return
-
-    def cut(self):
-        self._store(self._serializeSelected(delete=True))
-
-    def copy(self):
-        self._store(self._serializeSelected(delete=False))
-
-    def paste(self):
-        self._deserializeData(self._gatherData())

--- a/opencodeblocks/graphics/scene/history.py
+++ b/opencodeblocks/graphics/scene/history.py
@@ -36,11 +36,12 @@ class SceneHistory():
             self.current += 1
             self.restore()
 
-    def checkpoint(self, description:str):
+    def checkpoint(self, description:str, set_modified=True):
         """ Store a snapshot of the scene in the history stack.
 
         Args:
             description: Description given to this checkpoint.
+            set_modified: Whether the scene should be considered modified.
 
         """
         history_stamp = {
@@ -48,6 +49,8 @@ class SceneHistory():
             'snapshot': self.scene.serialize()
         }
         self.store(history_stamp)
+        if set_modified:
+            self.scene.has_been_modified = True
 
     def store(self, data:Any):
         """ Store new data in the history stack, updating current checkpoint.

--- a/opencodeblocks/graphics/view.py
+++ b/opencodeblocks/graphics/view.py
@@ -135,7 +135,7 @@ class OCBView(QGraphicsView):
         scene = self.scene()
         for selected_item in scene.selectedItems():
             selected_item.remove()
-        scene.history.checkpoint("Delete selected elements")
+        scene.history.checkpoint("Delete selected elements", set_modified=True)
 
     def drag_scene(self, event: QMouseEvent, action="press"):
         """ Drag the scene around. """
@@ -174,7 +174,7 @@ class OCBView(QGraphicsView):
                     item_at_click.add_edge(self.edge_drag)
                     self.edge_drag.destination_socket = item_at_click
                     self.edge_drag.update_path()
-                    scene.history.checkpoint("Created edge by dragging")
+                    scene.history.checkpoint("Created edge by dragging", set_modified=True)
                 else:
                     self.edge_drag.remove_from_sockets()
                     scene.removeItem(self.edge_drag)


### PR DESCRIPTION
- Add file_has_changed dialog to prevent work loss on Quit, Open and New.
- Add file name in the window title.
- Add star in the widow title when file has changed.