### PR TITLE
:beetle: editing a block resets output's states

### DIFF
--- a/opencodeblocks/blocks/codeblock.py
+++ b/opencodeblocks/blocks/codeblock.py
@@ -211,7 +211,6 @@ class OCBCodeBlock(OCBExecutableBlock):
             output_blocks, _ = self.custom_bfs(self, reverse=True)
             for block in output_blocks:
                 block.has_been_run = False
-            self._source = value
             self.has_been_run = False
             self.source_editor.setText(value)
             self._source = value

--- a/opencodeblocks/blocks/codeblock.py
+++ b/opencodeblocks/blocks/codeblock.py
@@ -5,13 +5,12 @@
 
 from typing import OrderedDict, Optional
 from PyQt5.QtWidgets import (
-    QApplication,
     QPushButton,
     QTextEdit,
     QWidget,
     QStyleOptionGraphicsItem,
 )
-from PyQt5.QtCore import QTimer, Qt
+from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QPen, QColor, QPainter, QPainterPath
 
 from ansi2html import Ansi2HTMLConverter
@@ -19,7 +18,6 @@ from ansi2html import Ansi2HTMLConverter
 from opencodeblocks.blocks.block import OCBBlock
 
 from opencodeblocks.blocks.executableblock import OCBExecutableBlock
-from opencodeblocks.graphics.socket import OCBSocket
 from opencodeblocks.graphics.pyeditor import PythonEditor
 
 conv = Ansi2HTMLConverter()
@@ -209,6 +207,11 @@ class OCBCodeBlock(OCBExecutableBlock):
     @source.setter
     def source(self, value: str):
         if value != self._source:
+            # If text has changed, set self and all output blocks to not run
+            output_blocks, _ = self.custom_bfs(self, reverse=True)
+            for block in output_blocks:
+                block.has_been_run = False
+            self._source = value
             self.has_been_run = False
             self.source_editor.setText(value)
             self._source = value


### PR DESCRIPTION
Editing a block will set all output blocks' has_been_run to False.
This allows rerunning the output blocks when an edit has been made on an upstream block

For a better example, see #126 

Fixes #126 