### PR TITLE
:beetle: removes kernel timeout

### DIFF
--- a/pyflow/core/kernel.py
+++ b/pyflow/core/kernel.py
@@ -124,7 +124,7 @@ class Kernel:
         """
         done = False
         try:
-            message = self.client.get_iopub_msg(timeout=2)["content"]
+            message = self.client.get_iopub_msg()["content"]
             if "execution_state" in message and message["execution_state"] == "idle":
                 done = True
         except queue.Empty:


### PR DESCRIPTION
TLDR: Removing a timeout fixes the bug where outputs are shown on the wrong blocks

At the beginning of the project, I put a 1-hour timeout on waiting for a message from the kernel.

It worked quite well until one day where we had an isolated incident that I could not reproduce (it was only happening in one virtual environement) where Pyflow was waiting 1 hour for a message that was not coming. I then switched the timeout to two seconds.

But now, on some long ipyg, this timeout creates issues where the output of one block is shown on another.

I have decided to remove this timeout for now until this creates issues in the beta.