### PR TITLE
:tada: Adds new shortcuts

### DIFF
--- a/pyflow/graphics/window.py
+++ b/pyflow/graphics/window.py
@@ -159,6 +159,12 @@ class Window(QMainWindow):
             shortcut="Del",
             triggered=self.onEditDelete,
         )
+        self._actDuplicate = QAction(
+            "&Duplicate",
+            statusTip="Duplicate selected items",
+            shortcut="Ctrl+D",
+            triggered=self.onEditDuplicate,
+        )
 
         # View
         self._actViewItems = QAction(
@@ -231,6 +237,7 @@ class Window(QMainWindow):
         self.editmenu.addAction(self._actPaste)
         self.editmenu.addSeparator()
         self.editmenu.addAction(self._actDel)
+        self.editmenu.addAction(self._actDuplicate)
 
         self.viewmenu = self.menuBar().addMenu("&View")
         self.thememenu = self.viewmenu.addMenu("Theme")
@@ -422,6 +429,13 @@ class Window(QMainWindow):
         current_window = self.activeMdiChild()
         if self.is_not_editing(current_window):
             current_window.view.deleteSelected()
+
+    def onEditDuplicate(self):
+        """Duplicate the selected items if not in edit mode."""
+        current_window = self.activeMdiChild()
+        if self.is_not_editing(current_window):
+            self.clipboard.copy(current_window.scene)
+            self.clipboard.paste(current_window.scene)
 
     # def closeEvent(self, event:QEvent):
     #     """ Save and quit the application. """

--- a/pyflow/graphics/window.py
+++ b/pyflow/graphics/window.py
@@ -165,6 +165,12 @@ class Window(QMainWindow):
             shortcut="Ctrl+D",
             triggered=self.onEditDuplicate,
         )
+        self._actRun = QAction(
+            "&Run",
+            statusTip="Run the selected block",
+            shortcut="Shift+Return",
+            triggered=self.onEditRun,
+        )
 
         # View
         self._actViewItems = QAction(
@@ -238,6 +244,7 @@ class Window(QMainWindow):
         self.editmenu.addSeparator()
         self.editmenu.addAction(self._actDel)
         self.editmenu.addAction(self._actDuplicate)
+        self.editmenu.addAction(self._actRun)
 
         self.viewmenu = self.menuBar().addMenu("&View")
         self.thememenu = self.viewmenu.addMenu("Theme")
@@ -436,6 +443,13 @@ class Window(QMainWindow):
         if self.is_not_editing(current_window):
             self.clipboard.copy(current_window.scene)
             self.clipboard.paste(current_window.scene)
+
+    def onEditRun(self):
+        """Run the selected block if there is only one block selected."""
+        current_window = self.activeMdiChild()
+        selected_blocks, _ = current_window.scene.sortedSelectedItems()
+        if len(selected_blocks) == 1:
+            selected_blocks[0].run_code()
 
     # def closeEvent(self, event:QEvent):
     #     """ Save and quit the application. """

--- a/pyflow/graphics/window.py
+++ b/pyflow/graphics/window.py
@@ -89,7 +89,7 @@ class Window(QMainWindow):
         self._actNew = QAction(
             "&New",
             statusTip="Create new ipygraph",
-            shortcut="Ctrl+N",
+            shortcut="Ctrl+Shift+N",
             triggered=self.onFileNew,
         )
         self._actOpen = QAction(

--- a/pyflow/graphics/window.py
+++ b/pyflow/graphics/window.py
@@ -89,7 +89,7 @@ class Window(QMainWindow):
         self._actNew = QAction(
             "&New",
             statusTip="Create new ipygraph",
-            shortcut="Ctrl+Shift+N",
+            shortcut="Ctrl+N",
             triggered=self.onFileNew,
         )
         self._actOpen = QAction(

--- a/pyflow/graphics/window.py
+++ b/pyflow/graphics/window.py
@@ -449,7 +449,7 @@ class Window(QMainWindow):
         current_window = self.activeMdiChild()
         selected_blocks, _ = current_window.scene.sortedSelectedItems()
         if len(selected_blocks) == 1:
-            selected_blocks[0].run_code()
+            selected_blocks[0].run_left()
 
     # def closeEvent(self, event:QEvent):
     #     """ Save and quit the application. """


### PR DESCRIPTION
Adds new shortcuts:
- Ctrl + D to duplicate the selection
- Shift + Enter to run the selected block only ( I can change it to run_left if you want )
- Ctrl + Shift + N to create a new window

Fixes #150 
Fixes #189 