### PR TITLE
:tada: Interrupts execution on error

### DIFF
--- a/pyflow/blocks/executableblock.py
+++ b/pyflow/blocks/executableblock.py
@@ -332,6 +332,10 @@ class ExecutableBlock(Block):
         """Called when the output is an error."""
         self.has_been_run = False
 
+    def error_occured(self):
+        """Interrupt the kernel if an error occured"""
+        self._interrupt_execution()
+
     @property
     @abstractmethod
     def source(self) -> str:

--- a/pyflow/core/kernel.py
+++ b/pyflow/core/kernel.py
@@ -72,14 +72,14 @@ class Kernel:
             block: CodeBlock to send the output to
             code: String representing a piece of Python code to execute
         """
-        worker = Worker(self, code)
+        worker = Worker(self, block, code)
         # Change color to running
         block.run_state = 1
         worker.signals.stdout.connect(block.handle_stdout)
         worker.signals.image.connect(block.handle_image)
         worker.signals.finished.connect(self.run_queue)
         worker.signals.finished.connect(block.execution_finished)
-        worker.signals.error.connect(block.reset_has_been_run)
+        worker.signals.error.connect(block.error_occured)
         block.scene().threadpool.start(worker)
 
     def run_queue(self):

--- a/pyflow/core/worker.py
+++ b/pyflow/core/worker.py
@@ -20,11 +20,12 @@ class WorkerSignals(QObject):
 class Worker(QRunnable):
     """Worker thread."""
 
-    def __init__(self, kernel, code):
+    def __init__(self, kernel, block, code):
         """Initialize the worker object."""
         super().__init__()
 
         self.kernel = kernel
+        self.block = block
         self.code = code
         self.signals = WorkerSignals()
 
@@ -43,6 +44,7 @@ class Worker(QRunnable):
                 elif output_type == "image":
                     self.signals.image.emit(output)
                 elif output_type == "error":
+                    self.block.reset_has_been_run()
                     self.signals.error.emit()
                     self.signals.stdout.emit(output)
         self.signals.finished.emit()


### PR DESCRIPTION
Interrupts the execution if there is an error and resets the state of the blocks that were in the execution queue and the block that errored out.

Fixes #215 