### PR TITLE
:tada: Improve markdown edditing

### DIFF
--- a/pyflow/blocks/blockfiles/markdown.pfb
+++ b/pyflow/blocks/blockfiles/markdown.pfb
@@ -2,7 +2,7 @@
     "title": "Markdown",
     "block_type": "MarkdownBlock",
     "text": "",
-    "splitter_pos": [88,41],
+    "splitter_pos": [88,0],
     "width": 618,
     "height": 184,
     "metadata": {

--- a/pyflow/blocks/markdownblock.py
+++ b/pyflow/blocks/markdownblock.py
@@ -71,23 +71,34 @@ class MarkdownBlock(Block):
 
     def hoverLeaveEvent(self, event: "QGraphicsSceneHoverEvent") -> None:
         """Handle the event when the mouse enters the block."""
-        self.move_splitter_up()
+        if not self.viewing_is_available():
+            self.move_splitter_up()
         return super().hoverLeaveEvent(event)
 
     def hoverEnterEvent(self, event: "QGraphicsSceneHoverEvent") -> None:
         """Handle the event when the mouse leaves the block."""
-        if self.isSelected():
+        if self.isSelected() and not self.editing_is_available():
             self.move_splitter_down()
         return super().hoverLeaveEvent(event)
 
     def setSelected(self, selected: bool) -> None:
         """Handle the changes in selection state."""
 
-        # If the user selects the block, move the splitter down
-        if selected and not self.isSelected():
+        # If the user selects the block,
+        # and the editing mode is not available,
+        # move the splitter down
+        if selected and not self.editing_is_available():
             self.move_splitter_down()
 
         return super().setSelected(selected)
+
+    def editing_is_available(self):
+        """Return True if the splitter isn't fully to the top."""
+        return self.splitter.sizes()[0] > 0
+
+    def viewing_is_available(self):
+        """Return True if the splitter isn't fully to the bottom."""
+        return self.splitter.sizes()[1] > 0
 
     def valueChanged(self):
         """Update markdown rendering when the content of the markdown editor changes."""

--- a/pyflow/blocks/markdownblock.py
+++ b/pyflow/blocks/markdownblock.py
@@ -55,11 +55,45 @@ class MarkdownBlock(Block):
         self.splitter.addWidget(self.rendered_markdown)
         self.holder.setWidget(self.root)
 
+        self.setAcceptHoverEvents(True)
+
+    def move_splitter_up(self):
+        """Move the splitter to the top of the block.
+
+        This is the viewing mode."""
+        self.splitter.setSizes([0, 0])
+
+    def move_splitter_down(self):
+        """Move the splitter to the bottom of the block.
+
+        This is the editing mode."""
+        self.splitter.setSizes([1, 0])
+
+    def hoverLeaveEvent(self, event: "QGraphicsSceneHoverEvent") -> None:
+        """Handle the event when the mouse enters the block."""
+        self.move_splitter_up()
+        return super().hoverLeaveEvent(event)
+
+    def hoverEnterEvent(self, event: "QGraphicsSceneHoverEvent") -> None:
+        """Handle the event when the mouse leaves the block."""
+        if self.isSelected():
+            self.move_splitter_down()
+        return super().hoverLeaveEvent(event)
+
+    def setSelected(self, selected: bool) -> None:
+        """Handle the changes in selection state."""
+
+        # If the user selects the block, move the splitter down
+        if selected and not self.isSelected():
+            self.move_splitter_down()
+
+        return super().setSelected(selected)
+
     def valueChanged(self):
         """Update markdown rendering when the content of the markdown editor changes."""
         t = self.editor.text()
 
-        dark_theme =f'''
+        dark_theme = f'''
             <style>
                 *{{
                     background-color:"""{self.output_panel_background_color}""";


### PR DESCRIPTION
Leaving the block switch to viewing mode.
Clicking on the block, or entering a selected block switch to edit mode.
If the user wants to use md blocks the old way, just move the splitter in the middle, leaving the block or clicking on it won't affect the position of the splitter. This is not the default mode: now, by default, empty markdown blocks are in edit mode (the splitter is fully to the top). Thus, this won't affect old ipyg files.