### PR TITLE
🔧 Make add block button use the empty.pfb file

### DIFF
--- a/pyflow/graphics/view.py
+++ b/pyflow/graphics/view.py
@@ -510,8 +510,8 @@ class View(QGraphicsView):
             ):
                 # Link a new CodeBlock under the selected block
                 parent: CodeBlock = item_at_click.block
-                new_block = CodeBlock()
-                self.scene().addItem(new_block)
+                empty_code_block_path: str = os.path.join(BLOCKFILES_PATH, "empty.pfb") 
+                new_block = self.scene().create_block_from_file(empty_code_block_path, 0, 0)
                 parent.link_and_place(new_block)
                 scene.history.checkpoint(
                     "Created a new linked block", set_modified=True


### PR DESCRIPTION
This is cleaner, and make it so that the title isn't "New title" anymore.