### PR TITLE
:beetle: Prevent checkpoint when the scene has not changed

### DIFF
--- a/pyflow/scene/history.py
+++ b/pyflow/scene/history.py
@@ -3,7 +3,7 @@
 
 """ Module for the handling an OCBScene history. """
 
-from typing import TYPE_CHECKING, Optional, OrderedDict
+from typing import TYPE_CHECKING, Optional
 import logging
 
 from pyflow.core.history import History


### PR DESCRIPTION
Fixes #275 

The fix is not very beautiful (it computes the hash of the scene to check if it was changed), but straightforward solutions don't work with the current setup (for example, just checking that the history of the pyeditor hasn't changed doesn't cut it, because if you modify the block, then move around, then focus out, the pyeditor will consider that the last change did change the block). 

The solution I propose has the benefit of being robust against any "double checkpoint" that one might introduce in the future.

Furthermore, it doesn't cost more than the previous state of the program, since it was already serializing the whole scene every time.